### PR TITLE
Add basic fast-check tests

### DIFF
--- a/backend/tests/sup_test.ts
+++ b/backend/tests/sup_test.ts
@@ -1,6 +1,7 @@
 
 import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
-import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+import { assert, assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+import fc from 'https://cdn.skypack.dev/fast-check';
 
 Clarinet.test({
     name: "Ensure that <...>",
@@ -24,3 +25,125 @@ Clarinet.test({
         assertEquals(block.height, 3);
     },
 });
+
+Clarinet.test({
+  name: 'get-message returns none when write-sup is not called',
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    // Arrange
+    // Act
+    let results = [...accounts.values()].map(account => {
+      const who = types.principal(account.address);
+      const msg = chain.callReadOnlyFn(
+        'sup', 'get-message', [who], account.address);
+      return msg.result;
+    });
+
+    // Assert
+    assert(results.length > 0);
+    results.forEach(msg => msg.expectNone());
+  }
+});
+
+Clarinet.test({
+  name: 'write-sup returns expected string',
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    // Property-based test, runs 100 times by default.
+    fc.assert(fc.property(
+      // Generate pseudo-random 'lorem ipsum' string and a number.
+      fc.lorem(), fc.integer(1, 100), (lorem: string, integer: number) => {
+        // Arrange
+        const deployer = accounts.get('deployer')!;
+        const msg = types.utf8(lorem);
+        const stx = types.uint(integer);
+
+        // Act
+        const block = chain.mineBlock([
+          Tx.contractCall(
+            'sup', 'write-sup', [msg, stx], deployer.address)
+        ]);
+        const result = block.receipts[0].result;
+
+        // Assert
+        result
+          .expectOk()
+          .expectAscii('Sup written successfully');
+      })
+    );
+  }
+});
+
+Clarinet.test({
+  name: 'write-sup increases total count by 1',
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    // Property-based test, runs 100 times by default.
+    fc.assert(fc.property(
+      // Generate pseudo-random 'lorem ipsum' string and a number.
+      fc.lorem(), fc.integer(1, 100), (lorem: string, integer: number) => {
+        // Arrange
+        const deployer = accounts.get('deployer')!;
+        let startCount = chain.callReadOnlyFn(
+          'sup', 'get-sups', [], deployer.address).result;
+
+        const msg = types.utf8(lorem);
+        const stx = types.uint(integer);
+
+        // Act
+        chain.mineBlock([
+          Tx.contractCall(
+            'sup', 'write-sup', [msg, stx], deployer.address)
+        ]);
+
+        // Assert
+        const endCount = chain.callReadOnlyFn(
+          'sup', 'get-sups', [], deployer.address).result;
+
+        startCount = startCount.replace('u', ''); // u123 -> 123
+        endCount.expectUint(Number(startCount) + 1);
+      })
+    );
+  }
+});
+
+Clarinet.test({
+  name: 'sups are not specific to the tx-sender',
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    // Property-based test, runs 100 times by default.
+    fc.assert(fc.property(
+      // Generate pseudo-random 'lorem ipsum' string and a number.
+      fc.lorem(), fc.integer(1, 100), (lorem: string, integer: number) => {
+        // Arrange
+        const deployer = accounts.get('deployer')!;
+        let startCount = chain.callReadOnlyFn(
+          'sup', 'get-sups', [], deployer.address).result;
+
+        const msg = types.utf8(lorem);
+        const stx = types.uint(integer);
+
+        const addresses = [...accounts.values()]
+          .slice(0, -1)
+          .map(x => x.address);
+
+        // Act
+        const txs = addresses.map((_, i) =>
+          Tx.contractCall(
+            'sup', 'write-sup', [msg,stx], addresses[i]));
+        chain.mineBlock(txs);
+
+        let results = [...accounts.values()].map(account =>
+          chain.callReadOnlyFn(
+            'sup', 'get-sups', [], account.address).result
+        );
+
+        // Assert
+        assert(results.length > 0);
+
+        startCount = startCount.replace('u', ''); // u123 -> 123
+        const expectedCount = Number(startCount) + txs.length;
+
+        results.forEach(actualCount =>
+          actualCount.expectUint(expectedCount));
+      })
+    );
+  }
+});
+


### PR DESCRIPTION
so that the readers of the accompanying [article](https://dev.to/krgrs/built-on-bitcoin-an-introduction-to-full-stack-web3-development-with-stacks-me9) can also have a test-suite of both unit tests and property-based tests to look at.

I think it's a valuable addition, as it can highlight the importance of having a test-suite next to a Clarity contract, as a [feedback mechanism](https://blog.ploeh.dk/2011/04/29/Feedbackmechanismsandtradeoffs/), in addition to the newly added [check-checker](https://www.hiro.so/blog/new-safety-checks-in-clarinet).

This is the first time I'm actually interacting with the Stacks/Clarity community<sup>1</sup>, so please feel free to comment on the PR. It'll be more than welcome. :heart: 

<sup>1 However, I'm doing TDD, PBT, for more than a decade and so this test-suite might be biased a little bit.</sup>

 :beers: 